### PR TITLE
Fix: infinite loader by resetting fetching state

### DIFF
--- a/src/components/popup/PopupEpisodes.js
+++ b/src/components/popup/PopupEpisodes.js
@@ -10,7 +10,10 @@ export function PopupEpisodes({ episodes }) {
   const [isFetching, setIsFetching] = useState(true);
 
   useEffect(() => {
+    let mounted = true;
     if (!episodes?.length) {
+      setIsFetching(false);
+
       return;
     }
 
@@ -26,7 +29,12 @@ export function PopupEpisodes({ episodes }) {
         } else {
           setSeries(data);
         }
+      })
+      .finally(() => {
+        if (mounted) setIsFetching(false);
       });
+
+    return () => (mounted = false);
   }, [episodes]);
 
   if (isFetching) {


### PR DESCRIPTION
Reset fetching state in two cases:
1. Content was fetched
2. Zero content was fetched

And add guard in useEffect to prevent setting state in unmounted component