### PR TITLE
Fix: DataProvider dependencies related bug

### DIFF
--- a/src/components/providers/DataProvider.js
+++ b/src/components/providers/DataProvider.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useCallback } from 'react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 const API_URL = 'https://rickandmortyapi.com/api/character/';
@@ -11,7 +12,7 @@ export function DataProvider({ children }) {
   const [info, setInfo] = useState({});
   const [apiURL, setApiURL] = useState(API_URL);
 
-  const fetchData = async (url) => {
+  const fetchData = useCallback(async (url) => {
     setIsFetching(true);
     setIsError(false);
 
@@ -23,15 +24,17 @@ export function DataProvider({ children }) {
         setInfo(data.info);
       })
       .catch((e) => {
-        setIsFetching(false);
         setIsError(true);
         console.error(e);
+      })
+      .finally(() => {
+        setIsFetching(false);
       });
-  };
+  }, []);
 
   useEffect(() => {
     fetchData(apiURL);
-  }, [apiURL]);
+  }, [apiURL, fetchData]);
 
   const dataValue = useMemo(
     () => ({


### PR DESCRIPTION
Wrap fetchData with useCallback to prevent re-renders: 
- dataValue is memoized through useMemo, wich have fetchData as dependency

And move resetting isFetching state in finally block